### PR TITLE
Increase default ebs size to 30GB

### DIFF
--- a/terraform/modules/compute_environment/main.tf
+++ b/terraform/modules/compute_environment/main.tf
@@ -28,7 +28,7 @@ resource "aws_launch_template" "ecs-optimized" {
       delete_on_termination = "true"
       encrypted             = "false"
       snapshot_id           = data.aws_ami.latest-amazon-ecs-optimized.root_snapshot_id
-      volume_size           = var.use_ephemeral_storage == true ? 8 : var.ebs_volume_size
+      volume_size           = var.use_ephemeral_storage == true ? 30 : var.ebs_volume_size
     }
   }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- Batch computing environments are specified with a default EBS size of 8GB, which seems to be too small for modern Amazon Linux 2 snapshots. This results in Batch jobs staying in stage "RUNNABLE" forever.

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Hopefully, Batch jobs run!


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
