### PR TITLE
Add allocation_strategy parameter to compute_environment module

### DIFF
--- a/terraform/modules/compute_environment/README.md
+++ b/terraform/modules/compute_environment/README.md
@@ -2,8 +2,8 @@
 
 Terraform module creates a AWS Batch compute Environment using SPOT-EC2 instances with optional ephemeral storage.
 
-If ephemeral storage is selected (default), Compute Environment will choose from R5d and C5d EC2 instance families 
-and mount one of the available ephemeral storage device (SSD drive) as `/tmp`. 
+If ephemeral storage is selected (default), Compute Environment will choose from R5d and C5d EC2 instance families
+and mount one of the available ephemeral storage device (SSD drive) as `/tmp`.
 It will use the second available ephemeral storage device as SWAP drive.
 
 ## Requirements
@@ -26,6 +26,7 @@ It will use the second available ephemeral storage device as SWAP drive.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | bid\_percentage | n/a | `number` | `100` | no |
+| allocation\_strategy | [The allocation strategy defines behavior when AWS Batch needs additional capacity](https://docs.aws.amazon.com/batch/latest/userguide/allocation-strategies.html) | `string` | `BEST_FIT` | no |
 | compute\_environment\_name | n/a | `string` | `"ephemeral_storage"` | no |
 | ebs\_volume\_size | n/a | `number` | `8` | no |
 | ecs\_role\_policy\_arns | n/a | `list(string)` | n/a | yes |

--- a/terraform/modules/compute_environment/main.tf
+++ b/terraform/modules/compute_environment/main.tf
@@ -52,6 +52,7 @@ resource "aws_batch_compute_environment" "default" {
   compute_resources {
 
     bid_percentage = var.bid_percentage
+    allocation_strategy = var.allocation_strategy
     ec2_key_pair   = var.key_pair
 
     instance_role       = aws_iam_instance_profile.ecs_instance_role.arn

--- a/terraform/modules/compute_environment/varibales.tf
+++ b/terraform/modules/compute_environment/varibales.tf
@@ -49,6 +49,11 @@ variable "bid_percentage" {
   default = 100
 }
 
+variable "allocation_strategy" {
+  type    = string
+  default = "BEST_FIT"
+}
+
 variable "max_vcpus" {
   type    = number
   default = 256


### PR DESCRIPTION


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
`allocation_strategy` is not specified and always uses `BEST_FIT`

When using a wide range of instance types this appears to be causing a spot market allocation issue as of few days ago.
The behavior appears to be as follows:
1. AWS Batch matches resource request to available instance type (ex: `r5d.2xlarge`)
2. The spot price for r5d is used (ex: 0.5$)
3. Larger instances are weighted down respective to their instance size (ex: `r5d.4xlarge` gets assigned a price of 0.2$)
4. When original instance type can not be allocated fleet request rolls over to larger instance type
5. If larger instance type spot price is higher than assigned fraction (likely) the request gets caught in fail loop

[BEST_FIT_PROGRESSIVE](https://docs.aws.amazon.com/batch/latest/userguide/allocation-strategies.html) allocation strategy appears to address this failure.

It's totally unclear why this behavior has changed as of few days ago.

## What is the new behavior?

The instance allocation seems to happen as expected 🤷 

## Does this introduce a breaking change?

- [x] No
