### PR TITLE
Fix communication between Batch instances and ECS tasks

### DIFF
--- a/terraform/modules/fargate_autoscaling/firewall.tf
+++ b/terraform/modules/fargate_autoscaling/firewall.tf
@@ -14,7 +14,6 @@ resource "aws_security_group" "lb" {
   )
 }
 
-# Externally defined ingress rules for ALB Security Group
 resource "aws_security_group_rule" "alb_ingress_http" {
   security_group_id = var.load_balancer_security_group == "" ? aws_security_group.lb[0].id : var.load_balancer_security_group
   protocol          = "tcp"
@@ -78,7 +77,7 @@ resource "aws_security_group_rule" "lb_task_egress" {
   source_security_group_id = aws_security_group.ecs_tasks.id
 }
 
-# Security group for Batch jobs
+# Security group for Batch instances
 resource "aws_security_group" "batch_instances" {
   name        = substr("${var.project}-batch-instances${var.name_suffix}", 0, 64)
   description = "Security group for AWS Batch jobs"
@@ -92,11 +91,22 @@ resource "aws_security_group" "batch_instances" {
   )
 }
 
-resource "aws_security_group_rule" "ecs_tasks_egress_batch" {
-  security_group_id = aws_security_group.ecs_tasks.id
-  protocol          = "tcp"
-  from_port         = var.listener_port
-  to_port           = var.listener_port
-  source_security_group_id = aws_security_group.batch_instances.id
+# Egress rule for Batch instances (if needed, otherwise default egress allows all)
+resource "aws_security_group_rule" "batch_instances_egress" {
+  security_group_id = aws_security_group.batch_instances.id
+  protocol          = "-1"
+  from_port         = 0
+  to_port           = 0
+  cidr_blocks       = ["0.0.0.0/0"]
   type              = "egress"
+}
+
+# Allow Batch instances to communicate with ECS Tasks
+resource "aws_security_group_rule" "ecs_tasks_ingress_batch" {
+  security_group_id        = aws_security_group.ecs_tasks.id
+  protocol                 = "tcp"
+  from_port                = var.listener_port
+  to_port                  = var.listener_port
+  source_security_group_id = aws_security_group.batch_instances.id
+  type                     = "ingress"
 }

--- a/terraform/modules/fargate_autoscaling/firewall.tf
+++ b/terraform/modules/fargate_autoscaling/firewall.tf
@@ -98,6 +98,6 @@ resource "aws_security_group_rule" "ecs_tasks_ingress_batch" {
   protocol          = "tcp"
   from_port         = var.listener_port
   to_port           = var.listener_port
-  source_security_group_id = aws_security_group.batch_jobs.id
+  source_security_group_id = aws_security_group.batch_instances.id
   type              = "ingress"
 }

--- a/terraform/modules/fargate_autoscaling/firewall.tf
+++ b/terraform/modules/fargate_autoscaling/firewall.tf
@@ -16,6 +16,7 @@ resource "aws_security_group" "lb" {
 
 # Externally defined ingress rules for ALB Security Group
 resource "aws_security_group_rule" "alb_ingress_http" {
+  count             = var.load_balancer_security_group == "" ? 1 : 0
   security_group_id = var.load_balancer_security_group == "" ? aws_security_group.lb[0].id : var.load_balancer_security_group
   protocol          = "tcp"
   from_port         = var.acm_certificate_arn == null ? 80 : var.listener_port
@@ -50,7 +51,6 @@ resource "aws_security_group" "ecs_tasks" {
 
 # Externally defined ingress rule for ECS Tasks Security Group
 resource "aws_security_group_rule" "ecs_tasks_ingress" {
-  count                     = var.load_balancer_security_group == "" ? 1 : 0
   security_group_id         = aws_security_group.ecs_tasks.id
   protocol                  = "tcp"
   from_port                 = var.container_port

--- a/terraform/modules/fargate_autoscaling/firewall.tf
+++ b/terraform/modules/fargate_autoscaling/firewall.tf
@@ -16,7 +16,7 @@ resource "aws_security_group" "lb" {
 
 # Externally defined ingress rules for ALB Security Group
 resource "aws_security_group_rule" "alb_ingress_http" {
-  security_group_id = aws_security_group.lb[0].id
+  security_group_id = var.load_balancer_security_group == "" ? aws_security_group.lb.id : var.load_balancer_security_group.id
   protocol          = "tcp"
   from_port         = var.acm_certificate_arn == null ? 80 : var.listener_port
   to_port           = var.acm_certificate_arn == null ? 80 : var.listener_port
@@ -25,7 +25,8 @@ resource "aws_security_group_rule" "alb_ingress_http" {
 }
 
 resource "aws_security_group_rule" "alb_ingress_https" {
-  security_group_id = aws_security_group.lb[0].id
+  count             = var.acm_certificate_arn == null ? 0 : 1
+  security_group_id = aws_security_group.lb.id
   protocol          = "tcp"
   from_port         = 443
   to_port           = 443
@@ -49,12 +50,12 @@ resource "aws_security_group" "ecs_tasks" {
 
 # Externally defined ingress rule for ECS Tasks Security Group
 resource "aws_security_group_rule" "ecs_tasks_ingress" {
-  security_group_id = aws_security_group.ecs_tasks.id
-  protocol          = "tcp"
-  from_port         = var.container_port
-  to_port           = var.container_port
-  source_security_group_id = length(aws_security_group.lb) > 0 ? aws_security_group.lb[0].id : var.load_balancer_security_group
-  type              = "ingress"
+  security_group_id         = aws_security_group.ecs_tasks.id
+  protocol                  = "tcp"
+  from_port                 = var.container_port
+  to_port                   = var.container_port
+  source_security_group_id  = var.load_balancer_security_group == "" ? aws_security_group.lb.id : var.load_balancer_security_group
+  type                      = "ingress"
 }
 
 # Externally defined egress rule for ECS Tasks Security Group
@@ -69,7 +70,7 @@ resource "aws_security_group_rule" "ecs_tasks_egress" {
 
 # Egress rule for Load Balancer to ECS Tasks
 resource "aws_security_group_rule" "lb_task_egress" {
-  security_group_id        = length(aws_security_group.lb) == 1 ? aws_security_group.lb[0].id : var.load_balancer_security_group
+  security_group_id        = var.load_balancer_security_group == "" ? aws_security_group.lb.id : var.load_balancer_security_group
   from_port                = var.container_port
   to_port                  = var.container_port
   protocol                 = "tcp"

--- a/terraform/modules/fargate_autoscaling/firewall.tf
+++ b/terraform/modules/fargate_autoscaling/firewall.tf
@@ -93,13 +93,11 @@ resource "aws_security_group" "batch_instances" {
   )
 }
 
-# Rule to allow traffic from the Batch jobs to the ECS task,
-# allowing Batch jobs to "phone home" their progress
-resource "aws_security_group_rule" "ecs_tasks_ingress_batch" {
+resource "aws_security_group_rule" "ecs_tasks_egress_batch" {
   security_group_id = aws_security_group.ecs_tasks.id
   protocol          = "tcp"
   from_port         = var.listener_port
   to_port           = var.listener_port
   source_security_group_id = aws_security_group.batch_instances.id
-  type              = "ingress"
+  type              = "egress"
 }

--- a/terraform/modules/fargate_autoscaling/firewall.tf
+++ b/terraform/modules/fargate_autoscaling/firewall.tf
@@ -16,7 +16,6 @@ resource "aws_security_group" "lb" {
 
 # Externally defined ingress rules for ALB Security Group
 resource "aws_security_group_rule" "alb_ingress_http" {
-  count             = var.load_balancer_security_group == "" ? 1 : 0
   security_group_id = var.load_balancer_security_group == "" ? aws_security_group.lb[0].id : var.load_balancer_security_group
   protocol          = "tcp"
   from_port         = var.acm_certificate_arn == null ? 80 : var.listener_port

--- a/terraform/modules/fargate_autoscaling/firewall.tf
+++ b/terraform/modules/fargate_autoscaling/firewall.tf
@@ -1,25 +1,10 @@
-# ALB Security group
+# ALB Security Group
 # This is the group you need to edit if you want to restrict access to your application
 resource "aws_security_group" "lb" {
   count       = var.load_balancer_security_group == "" ? 1 : 0
   name        = substr("${var.project}-ecs-alb${var.name_suffix}", 0, 64)
   description = "Controls access to the ALB"
   vpc_id      = var.vpc_id
-
-  # When using SSL certificate open port 80 for ingress, otherwise user specific port
-  ingress {
-    protocol    = "tcp"
-    from_port   = var.acm_certificate_arn == null ? 80 : var.listener_port
-    to_port     = var.acm_certificate_arn == null ? 80 : var.listener_port
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    protocol    = "tcp"
-    from_port   = 443
-    to_port     = 443
-    cidr_blocks = ["0.0.0.0/0"]
-  }
 
   tags = merge(
     {
@@ -29,38 +14,30 @@ resource "aws_security_group" "lb" {
   )
 }
 
-
-# Open container port for egress and link with ECS Task security group
-resource "aws_security_group_rule" "lb_task_egress" {
-  security_group_id        = length(aws_security_group.lb) == 1 ? aws_security_group.lb[0].id : var.load_balancer_security_group
-  from_port                = var.container_port
-  to_port                  = var.container_port
-  protocol                 = "tcp"
-  type                     = "egress"
-  source_security_group_id = aws_security_group.ecs_tasks.id
+# Externally defined ingress rules for ALB Security Group
+resource "aws_security_group_rule" "alb_ingress_http" {
+  security_group_id = aws_security_group.lb[0].id
+  protocol          = "tcp"
+  from_port         = var.acm_certificate_arn == null ? 80 : var.listener_port
+  to_port           = var.acm_certificate_arn == null ? 80 : var.listener_port
+  cidr_blocks       = ["0.0.0.0/0"]
+  type              = "ingress"
 }
 
+resource "aws_security_group_rule" "alb_ingress_https" {
+  security_group_id = aws_security_group.lb[0].id
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks       = ["0.0.0.0/0"]
+  type              = "ingress"
+}
 
-# Traffic to the ECS Cluster should only come from the ALB
-# Tasks should be able to communicate with any external resource
+# ECS Tasks Security Group
 resource "aws_security_group" "ecs_tasks" {
   name        = substr("${var.project}-ecs-tasks${var.name_suffix}", 0, 64)
   description = "Allow inbound access from the ALB only"
   vpc_id      = var.vpc_id
-
-  ingress {
-    protocol        = "tcp"
-    from_port       = var.container_port
-    to_port         = var.container_port
-    security_groups = length(aws_security_group.lb) > 0 ? [aws_security_group.lb[0].id] : [var.load_balancer_security_group]
-  }
-
-  egress {
-    protocol    = "-1"
-    from_port   = 0
-    to_port     = 0
-    cidr_blocks = ["0.0.0.0/0"]
-  }
 
   tags = merge(
     {
@@ -70,12 +47,57 @@ resource "aws_security_group" "ecs_tasks" {
   )
 }
 
-resource "aws_security_group_rule" "lb" {
-  count             = var.load_balancer_security_group == "" ? 0 : 1
+# Externally defined ingress rule for ECS Tasks Security Group
+resource "aws_security_group_rule" "ecs_tasks_ingress" {
+  security_group_id = aws_security_group.ecs_tasks.id
+  protocol          = "tcp"
+  from_port         = var.container_port
+  to_port           = var.container_port
+  source_security_group_id = length(aws_security_group.lb) > 0 ? aws_security_group.lb[0].id : var.load_balancer_security_group
   type              = "ingress"
+}
+
+# Externally defined egress rule for ECS Tasks Security Group
+resource "aws_security_group_rule" "ecs_tasks_egress" {
+  security_group_id = aws_security_group.ecs_tasks.id
+  protocol          = "-1"
+  from_port         = 0
+  to_port           = 0
+  cidr_blocks       = ["0.0.0.0/0"]
+  type              = "egress"
+}
+
+# Egress rule for Load Balancer to ECS Tasks
+resource "aws_security_group_rule" "lb_task_egress" {
+  security_group_id        = length(aws_security_group.lb) == 1 ? aws_security_group.lb[0].id : var.load_balancer_security_group
+  from_port                = var.container_port
+  to_port                  = var.container_port
+  protocol                 = "tcp"
+  type                     = "egress"
+  source_security_group_id = aws_security_group.ecs_tasks.id
+}
+
+# Security group for Batch jobs
+resource "aws_security_group" "batch_instances" {
+  name        = substr("${var.project}-batch-instances${var.name_suffix}", 0, 64)
+  description = "Security group for AWS Batch jobs"
+  vpc_id      = var.vpc_id
+
+  tags = merge(
+    {
+      Name = substr("${var.project}-batch-instances${var.name_suffix}", 0, 64)
+    },
+    var.tags
+  )
+}
+
+# Rule to allow traffic from the Batch jobs to the ECS task,
+# allowing Batch jobs to "phone home" their progress
+resource "aws_security_group_rule" "ecs_tasks_ingress_batch" {
+  security_group_id = aws_security_group.ecs_tasks.id
+  protocol          = "tcp"
   from_port         = var.listener_port
   to_port           = var.listener_port
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = var.load_balancer_security_group
+  source_security_group_id = aws_security_group.batch_jobs.id
+  type              = "ingress"
 }

--- a/terraform/modules/fargate_autoscaling/firewall.tf
+++ b/terraform/modules/fargate_autoscaling/firewall.tf
@@ -91,16 +91,6 @@ resource "aws_security_group" "batch_instances" {
   )
 }
 
-# Egress rule for Batch instances (if needed, otherwise default egress allows all)
-resource "aws_security_group_rule" "batch_instances_egress" {
-  security_group_id = aws_security_group.batch_instances.id
-  protocol          = "-1"
-  from_port         = 0
-  to_port           = 0
-  cidr_blocks       = ["0.0.0.0/0"]
-  type              = "egress"
-}
-
 # Allow Batch instances to communicate with ECS Tasks
 resource "aws_security_group_rule" "ecs_tasks_ingress_batch" {
   security_group_id        = aws_security_group.ecs_tasks.id

--- a/terraform/modules/fargate_autoscaling/firewall.tf
+++ b/terraform/modules/fargate_autoscaling/firewall.tf
@@ -16,6 +16,7 @@ resource "aws_security_group" "lb" {
 
 # Externally defined ingress rules for ALB Security Group
 resource "aws_security_group_rule" "alb_ingress_http" {
+  count             = var.load_balancer_security_group == "" ? 1 : 0
   security_group_id = var.load_balancer_security_group == "" ? aws_security_group.lb[0].id : var.load_balancer_security_group
   protocol          = "tcp"
   from_port         = var.acm_certificate_arn == null ? 80 : var.listener_port
@@ -50,6 +51,7 @@ resource "aws_security_group" "ecs_tasks" {
 
 # Externally defined ingress rule for ECS Tasks Security Group
 resource "aws_security_group_rule" "ecs_tasks_ingress" {
+  count                     = var.load_balancer_security_group == "" ? 1 : 0
   security_group_id         = aws_security_group.ecs_tasks.id
   protocol                  = "tcp"
   from_port                 = var.container_port

--- a/terraform/modules/fargate_autoscaling/firewall.tf
+++ b/terraform/modules/fargate_autoscaling/firewall.tf
@@ -18,8 +18,8 @@ resource "aws_security_group" "lb" {
 resource "aws_security_group_rule" "alb_ingress_http" {
   security_group_id = var.load_balancer_security_group == "" ? aws_security_group.lb[0].id : var.load_balancer_security_group
   protocol          = "tcp"
-  from_port         = var.acm_certificate_arn == null ? 80 : var.listener_port
-  to_port           = var.acm_certificate_arn == null ? 80 : var.listener_port
+  from_port         = var.load_balancer_security_group == "" ? 80 : var.listener_port
+  to_port           = var.load_balancer_security_group == "" ? 80 : var.listener_port
   cidr_blocks       = ["0.0.0.0/0"]
   type              = "ingress"
 }

--- a/terraform/modules/fargate_autoscaling/firewall.tf
+++ b/terraform/modules/fargate_autoscaling/firewall.tf
@@ -16,7 +16,7 @@ resource "aws_security_group" "lb" {
 
 # Externally defined ingress rules for ALB Security Group
 resource "aws_security_group_rule" "alb_ingress_http" {
-  security_group_id = var.load_balancer_security_group == "" ? aws_security_group.lb[0].id : var.load_balancer_security_group.id
+  security_group_id = var.load_balancer_security_group == "" ? aws_security_group.lb[0].id : var.load_balancer_security_group
   protocol          = "tcp"
   from_port         = var.acm_certificate_arn == null ? 80 : var.listener_port
   to_port           = var.acm_certificate_arn == null ? 80 : var.listener_port

--- a/terraform/modules/fargate_autoscaling/firewall.tf
+++ b/terraform/modules/fargate_autoscaling/firewall.tf
@@ -16,7 +16,7 @@ resource "aws_security_group" "lb" {
 
 # Externally defined ingress rules for ALB Security Group
 resource "aws_security_group_rule" "alb_ingress_http" {
-  security_group_id = var.load_balancer_security_group == "" ? aws_security_group.lb.id : var.load_balancer_security_group.id
+  security_group_id = var.load_balancer_security_group == "" ? aws_security_group.lb[0].id : var.load_balancer_security_group.id
   protocol          = "tcp"
   from_port         = var.acm_certificate_arn == null ? 80 : var.listener_port
   to_port           = var.acm_certificate_arn == null ? 80 : var.listener_port
@@ -26,7 +26,7 @@ resource "aws_security_group_rule" "alb_ingress_http" {
 
 resource "aws_security_group_rule" "alb_ingress_https" {
   count             = var.acm_certificate_arn == null ? 0 : 1
-  security_group_id = aws_security_group.lb.id
+  security_group_id = aws_security_group.lb[0].id
   protocol          = "tcp"
   from_port         = 443
   to_port           = 443
@@ -54,7 +54,7 @@ resource "aws_security_group_rule" "ecs_tasks_ingress" {
   protocol                  = "tcp"
   from_port                 = var.container_port
   to_port                   = var.container_port
-  source_security_group_id  = var.load_balancer_security_group == "" ? aws_security_group.lb.id : var.load_balancer_security_group
+  source_security_group_id  = var.load_balancer_security_group == "" ? aws_security_group.lb[0].id : var.load_balancer_security_group
   type                      = "ingress"
 }
 
@@ -70,7 +70,7 @@ resource "aws_security_group_rule" "ecs_tasks_egress" {
 
 # Egress rule for Load Balancer to ECS Tasks
 resource "aws_security_group_rule" "lb_task_egress" {
-  security_group_id        = var.load_balancer_security_group == "" ? aws_security_group.lb.id : var.load_balancer_security_group
+  security_group_id        = var.load_balancer_security_group == "" ? aws_security_group.lb[0].id : var.load_balancer_security_group
   from_port                = var.container_port
   to_port                  = var.container_port
   protocol                 = "tcp"

--- a/terraform/modules/fargate_autoscaling/firewall.tf
+++ b/terraform/modules/fargate_autoscaling/firewall.tf
@@ -91,6 +91,16 @@ resource "aws_security_group" "batch_instances" {
   )
 }
 
+# Egress rule for Batch instances
+resource "aws_security_group_rule" "batch_instances_egress" {
+  security_group_id = aws_security_group.batch_instances.id
+  protocol          = "-1"
+  from_port         = 0
+  to_port           = 0
+  cidr_blocks       = ["0.0.0.0/0"]
+  type              = "egress"
+}
+
 # Allow Batch instances to communicate with ECS Tasks
 resource "aws_security_group_rule" "ecs_tasks_ingress_batch" {
   security_group_id        = aws_security_group.ecs_tasks.id

--- a/terraform/modules/fargate_autoscaling/outputs.tf
+++ b/terraform/modules/fargate_autoscaling/outputs.tf
@@ -26,3 +26,8 @@ output "ecs_update_service_policy_arn" {
   value       = aws_iam_policy.ecs_update_service_policy.arn
   description = "ARN of IAM policy to allow updating ECS service"
 }
+
+output "batch_security_group_id" {
+  value       = aws_security_group.batch_instances.id
+  description = "ID of the Batch instance security group."
+}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- Batch instances time-out trying to phone home their success or failure
- Also, per the docs, specifying inline rules in a SG and then externally defined rules can result in inconsistent behavior during apply

Issue Number: GTC-2860


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Batch instances report home okay
- All rules are externally define, removing inconsistency


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Data API PR (to attach the security group to the compute environments) to follow