### PR TITLE
Switch to using Amazon Linux 3 in the upgrade_to_aws_v4 branch (for Pro only)

### DIFF
--- a/terraform/modules/compute_environment/data.tf
+++ b/terraform/modules/compute_environment/data.tf
@@ -5,7 +5,7 @@ data "aws_ami" "latest-amazon-ecs-optimized" {
 
   filter {
     name   = "name"
-    values = ["amzn-ami-*-amazon-ecs-optimized"]
+    values = ["al2023-ami-ecs-*"]
   }
   filter {
     name   = "architecture"

--- a/terraform/modules/compute_environment/main.tf
+++ b/terraform/modules/compute_environment/main.tf
@@ -41,6 +41,18 @@ resource "aws_launch_template" "ecs-optimized" {
     resource_type = "volume"
     tags          = local.tags
   }
+  metadata_options {
+    # "optional" allows both IMDSv1 and IMDSv2. 
+    # Use "required" only if your Scala SDK is updated to a version that supports tokens.
+    http_tokens                 = "optional" 
+    
+    # "2" allows the metadata request to pass from the Docker container 
+    # to the EC2 host and then to the Metadata Service.
+    http_put_response_hop_limit = 2
+    
+    http_endpoint               = "enabled"
+  }
+
 
   user_data = var.use_ephemeral_storage == true ? data.local_file.mount_tmp_enable_swap.content_base64 : ""
 }

--- a/terraform/modules/compute_environment/main.tf
+++ b/terraform/modules/compute_environment/main.tf
@@ -18,6 +18,8 @@ resource "aws_launch_template" "ecs-optimized" {
   image_id                = data.aws_ami.latest-amazon-ecs-optimized.image_id
   security_group_names    = []
   tags                    = var.tags
+  # Automatically sets the latest version as the default version
+  update_default_version = true
 
   key_name = var.key_pair
 

--- a/terraform/modules/compute_environment/main.tf
+++ b/terraform/modules/compute_environment/main.tf
@@ -28,7 +28,7 @@ resource "aws_launch_template" "ecs-optimized" {
       delete_on_termination = "true"
       encrypted             = "false"
       snapshot_id           = data.aws_ami.latest-amazon-ecs-optimized.root_snapshot_id
-      volume_size           = var.use_ephemeral_storage == true ? 30 : var.ebs_volume_size
+      volume_size           = var.use_ephemeral_storage == true ? 50 : var.ebs_volume_size
     }
   }
 

--- a/terraform/modules/container_registry/scripts/push.sh
+++ b/terraform/modules/container_registry/scripts/push.sh
@@ -25,7 +25,9 @@ pushd "$ROOT_DIR"
 
 docker build -t "$IMAGE_NAME" -f "$DOCKER_FILE" .
 
-$(aws ecr get-login --no-include-email --region "$REGION")
+aws ecr get-login-password --region "$REGION" | docker login --username AWS \
+          --password-stdin 617001639586.dkr.ecr.$REGION.amazonaws.com
+
 docker tag "$IMAGE_NAME" "$REPOSITORY_URL":"$TAG"
 docker push "$REPOSITORY_URL":"$TAG"
 

--- a/terraform/modules/container_registry/scripts/push.sh
+++ b/terraform/modules/container_registry/scripts/push.sh
@@ -7,7 +7,7 @@
 # Usage:
 #
 # # Acquire an AWS session token
-# $ ./push.sh . 123456789012.dkr.ecr.us-west-1.amazonaws.com/hello-world latest
+# $ ./push.sh . 123456789012.dkr.ecr.us-west-1.amazonaws.com/name-of-ecr-repo latest
 #
 
 set -e
@@ -20,13 +20,15 @@ DOCKER_FILE="$DOCKER_PATH/${5:-Dockerfile}"
 
 REGION="$(echo "$REPOSITORY_URL" | cut -d. -f4)"
 IMAGE_NAME="$(echo "$REPOSITORY_URL" | cut -d/ -f2)"
+# The general ECR URL - the REPOSITORY_URL with the repo-name removed.
+ECR_URL="$(echo "$REPOSITORY_URL" | cut -d/ -f1)"
 
 pushd "$ROOT_DIR"
 
 docker build -t "$IMAGE_NAME" -f "$DOCKER_FILE" .
 
 aws ecr get-login-password --region "$REGION" | docker login --username AWS \
-          --password-stdin 617001639586.dkr.ecr.$REGION.amazonaws.com
+          --password-stdin ${ECR_URL}
 
 docker tag "$IMAGE_NAME" "$REPOSITORY_URL":"$TAG"
 docker push "$REPOSITORY_URL":"$TAG"


### PR DESCRIPTION
This will switch over GFWPro batch jobs to using AL3, since Amazon Linux 1 images are disappearing.
