### PR TITLE
Update push.sh script to use 'aws ecr get-login-password'

### DIFF
--- a/terraform/modules/container_registry/scripts/push.sh
+++ b/terraform/modules/container_registry/scripts/push.sh
@@ -2,12 +2,12 @@
 # 
 # Builds a Docker image and pushes to an AWS ECR repository
 #
-# Invoked by the terraform-aws-ecr-docker-image Terraform module.
+# Invoked by the container-registry module in gfw-terraform-modules
 #
 # Usage:
 #
 # # Acquire an AWS session token
-# $ ./push.sh . 123456789012.dkr.ecr.us-west-1.amazonaws.com/hello-world latest
+# $ ./push.sh . 123456789012.dkr.ecr.us-west-1.amazonaws.com/name-of-ecr-repo latest
 #
 
 set -e
@@ -20,12 +20,16 @@ DOCKER_FILE="$DOCKER_PATH/${5:-Dockerfile}"
 
 REGION="$(echo "$REPOSITORY_URL" | cut -d. -f4)"
 IMAGE_NAME="$(echo "$REPOSITORY_URL" | cut -d/ -f2)"
+# The general ECR URL - the REPOSITORY_URL with the repo-name removed.
+ECR_URL="$(echo "$REPOSITORY_URL" | cut -d/ -f1)"
 
 pushd "$ROOT_DIR"
 
 docker build -t "$IMAGE_NAME" -f "$DOCKER_FILE" .
 
-$(aws ecr get-login --no-include-email --region "$REGION")
+aws ecr get-login-password --region "$REGION" | docker login --username AWS \
+          --password-stdin ${ECR_URL}
+
 docker tag "$IMAGE_NAME" "$REPOSITORY_URL":"$TAG"
 docker push "$REPOSITORY_URL":"$TAG"
 


### PR DESCRIPTION
Replace 'aws ecr get-login' with 'aws ecr get-login-password', because newer versions of the aws command don't support get-login anymore.
